### PR TITLE
Add missing localizations, fix Xcode < 9.3 compatibility, fix Android parity

### DIFF
--- a/PersonalizedAdConsent/PersonalizedAdConsent.xcodeproj/project.pbxproj
+++ b/PersonalizedAdConsent/PersonalizedAdConsent.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 48;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -78,8 +78,15 @@
 		5A92D2A12076961800FFE51D /* PersonalizedAdConsent */ = {
 			isa = PBXGroup;
 			children = (
-				5A5022F020AF782A00E98A1F /* PersonalizedAdConsent.bundle */,
-				5A4B555A209239AB000E14B8 /* module.modulemap */,
+				DBCED54120B48CB700455363 /* Resources */,
+				DB862D5620B48C98006F9EA8 /* Sources */,
+			);
+			path = PersonalizedAdConsent;
+			sourceTree = "<group>";
+		};
+		DB862D5620B48C98006F9EA8 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
 				5A5669CB20AE28170061B6B2 /* PersonalizedAdConsent.h */,
 				5A92D2A22076961800FFE51D /* PACPersonalizedAdConsent.h */,
 				5A92D2B92076965D00FFE51D /* PACPersonalizedAdConsent.m */,
@@ -89,9 +96,18 @@
 				5A20E047208A788A0012D068 /* PACView.m */,
 				5A4B54FA2090D7FE000E14B8 /* PACConsentForm.h */,
 				5A647C3B208A7AE4004B88F0 /* PACConsentForm.m */,
+			);
+			name = Sources;
+			sourceTree = "<group>";
+		};
+		DBCED54120B48CB700455363 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				5A5022F020AF782A00E98A1F /* PersonalizedAdConsent.bundle */,
+				5A4B555A209239AB000E14B8 /* module.modulemap */,
 				5A92D2A32076961800FFE51D /* Info.plist */,
 			);
-			path = PersonalizedAdConsent;
+			name = Resources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -142,11 +158,12 @@
 				TargetAttributes = {
 					5A92D29E2076961800FFE51D = {
 						CreatedOnToolsVersion = 9.3;
+						ProvisioningStyle = Automatic;
 					};
 				};
 			};
 			buildConfigurationList = 5A92D2992076961800FFE51D /* Build configuration list for PBXProject "PersonalizedAdConsent" */;
-			compatibilityVersion = "Xcode 9.3";
+			compatibilityVersion = "Xcode 8.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -316,11 +333,7 @@
 				INFOPLIST_FILE = PersonalizedAdConsent/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "$(SRCROOT)/PersonalizedAdConsent/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.PersonalizedAdConsent;
@@ -343,11 +356,7 @@
 				INFOPLIST_FILE = PersonalizedAdConsent/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-					"@loader_path/Frameworks",
-				);
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = "$(SRCROOT)/PersonalizedAdConsent/module.modulemap";
 				PRODUCT_BUNDLE_IDENTIFIER = com.google.PersonalizedAdConsent;

--- a/PersonalizedAdConsent/PersonalizedAdConsent/PACConsentForm.h
+++ b/PersonalizedAdConsent/PersonalizedAdConsent/PACConsentForm.h
@@ -18,7 +18,7 @@
 
 /// Called after load completes. `error` is set if the load failed.
 typedef void (^PACLoadCompletion)(NSError *_Nullable error);
-typedef void (^PACDismissCompletion)(NSError *_Nullable error, BOOL userPrefersAdFree);
+typedef void (^PACDismissCompletion)(NSError *_Nullable error, PACConsentStatus consentStatus, BOOL userPrefersAdFree);
 
 /// A single use consent form object.
 @interface PACConsentForm : NSObject

--- a/PersonalizedAdConsent/PersonalizedAdConsent/PACPersonalizedAdConsent.h
+++ b/PersonalizedAdConsent/PersonalizedAdConsent/PACPersonalizedAdConsent.h
@@ -68,11 +68,11 @@ typedef void (^PACConsentInformationUpdateHandler)(NSError *_Nullable error);
     BOOL requestLocationInEEAOrUnknown;
 
 /// Array of ad providers.
-@property(nonatomic, readonly, nullable) NSArray<PACAdProvider *> *adProviders;
+@property(nonatomic, readonly, nullable, copy) NSArray<PACAdProvider *> *adProviders;
 
 /// Array of advertising identifier UUID strings. Debug features are enabled for devices with these
 /// identifiers. Debug features are always enabled for simulators.
-@property(nonatomic, nullable) NSArray<NSString *> *debugIdentifiers;
+@property(nonatomic, nullable, copy) NSArray<NSString *> *debugIdentifiers;
 
 /// Debug geography. Used for debug devices only.
 @property(nonatomic) PACDebugGeography debugGeography;

--- a/PersonalizedAdConsent/PersonalizedAdConsent/PACPersonalizedAdConsent.m
+++ b/PersonalizedAdConsent/PersonalizedAdConsent/PACPersonalizedAdConsent.m
@@ -361,7 +361,7 @@ PACDeserializeAdProviders(NSArray<NSDictionary *> *_Nullable serializedProviders
   NSMutableArray *notFoundPublisherIdentifiers = [[NSMutableArray alloc] init];
   NSArray<NSDictionary *> *adNetworks = info[@"ad_network_ids"];
   for (NSDictionary<NSString *, id> *adNetwork in adNetworks) {
-    NSString *publisherIdentifier = adNetwork[@"ad_network_id"] ?: @"Publisher identifier missing";
+    NSString *publisherIdentifier = adNetwork[@"ad_network_id"] ?: NSLocalizedString(@"Publisher identifier missing", nil);
     NSNumber *lookupFailed = adNetwork[@"lookup_failed"] ?: @NO;
     NSNumber *notFound = adNetwork[@"not_found"] ?: @NO;
     if (lookupFailed.boolValue) {
@@ -377,13 +377,13 @@ PACDeserializeAdProviders(NSArray<NSDictionary *> *_Nullable serializedProviders
   }
 
   NSMutableArray *errorMessages = [[NSMutableArray alloc] init];
-  [errorMessages addObject:@"Response error."];
+  [errorMessages addObject:NSLocalizedString(@"Response error.", nil)];
 
   if (lookupFailedPublisherIdentifiers.count) {
     NSString *commaSeparatedPublisherIdentifiers =
         [lookupFailedPublisherIdentifiers componentsJoinedByString:@", "];
     NSString *message = [[NSString alloc]
-        initWithFormat:@"Lookup failure for: %@", commaSeparatedPublisherIdentifiers];
+        initWithFormat:NSLocalizedString(@"Lookup failure for: %@", nil), commaSeparatedPublisherIdentifiers];
     [errorMessages addObject:message];
   }
 
@@ -391,7 +391,7 @@ PACDeserializeAdProviders(NSArray<NSDictionary *> *_Nullable serializedProviders
     NSString *commaSeparatedPublisherIdentifiers =
         [notFoundPublisherIdentifiers componentsJoinedByString:@", "];
     NSString *message = [[NSString alloc]
-        initWithFormat:@"Publisher identifiers not found: %@", commaSeparatedPublisherIdentifiers];
+        initWithFormat:NSLocalizedString(@"Publisher identifiers not found: %@", nil), commaSeparatedPublisherIdentifiers];
     [errorMessages addObject:message];
   }
 

--- a/PersonalizedAdConsent/PersonalizedAdConsent/PACView.m
+++ b/PersonalizedAdConsent/PersonalizedAdConsent/PACView.m
@@ -226,7 +226,7 @@ PACQueryParametersFromURL(NSURL *_Nonnull URL) {
     if (self->_dismissCompletion) {
       NSError *error = formStatus[PACFormStatusKeyError];
       NSNumber *userPrefersAdFreeNumber = formStatus[PACFormStatusKeyUserPrefersAdFree];
-      self->_dismissCompletion(error, userPrefersAdFreeNumber.boolValue);
+      self->_dismissCompletion(error, PACConsentInformation.sharedInstance.consentStatus, userPrefersAdFreeNumber.boolValue);
     }
     self->_dismissCompletion = nil;
   });


### PR DESCRIPTION
Hey there! This PR attempts to:
- [x] add the missing localizations (#5)
- [x] fix the Xcode < 9.3 compatibility (#8)
- [x] fix the Android parity by passing the `consentStatus` in the completion handler of consent form

I would also like to add the universal build target (#4) and podspec (#3) if that's something being considered.

P.S.: We already make heavy usage of this SDK in the [Titanium bindings](https://github.com/appcelerator-modules/ti.admob/pull/77), yey!