### PR TITLE
Fix issue with parsing JSON response in incorrect CP1251 encoding

### DIFF
--- a/PersonalizedAdConsent/PersonalizedAdConsent/PACPersonalizedAdConsent.m
+++ b/PersonalizedAdConsent/PersonalizedAdConsent/PACPersonalizedAdConsent.m
@@ -330,8 +330,12 @@ PACDeserializeAdProviders(NSArray<NSDictionary *> *_Nullable serializedProviders
                  return;
                }
 
-               NSDictionary<NSString *, id> *info =
-                   [NSJSONSerialization JSONObjectWithData:data options:0 error:&error];
+               NSString * dataString = [[NSString alloc] initWithData:data
+                                                             encoding:NSWindowsCP1251StringEncoding];
+               NSData * dataInUTFEncoding = [dataString dataUsingEncoding:NSUTF8StringEncoding];
+               NSDictionary<NSString *, id> *info = [NSJSONSerialization JSONObjectWithData:dataInUTFEncoding
+                                                                                    options:0
+                                                                                      error:&error];
                if (error || ![info isKindOfClass:[NSDictionary class]]) {
                  if (!error) {
                    error = PACErrorWithDescription(@"Invalid response.");


### PR DESCRIPTION
Issue: https://github.com/googleads/googleads-consent-sdk-ios/issues/13